### PR TITLE
Fixed broken workbook URL

### DIFF
--- a/workbook.md
+++ b/workbook.md
@@ -1,6 +1,6 @@
 ---
 layout: redirect
 permalink: /workbook
-redirect: https://hackathonsforschools.gitbook.io/student-summer-sprint-1/
+redirect: https://hackathons-for-schools.gitbook.io/student-summer-sprint-1/
 title: H4S S3 | Workbook
 ---


### PR DESCRIPTION
I just noticed that the URL for the workbook was linking to a 404 page, the URL needed some dashes